### PR TITLE
Allow text code editor to zoom independently of browser zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
@@ -103,6 +103,10 @@
               </input>
               <button id="sendButton" class="" title="Send Text">
                 SEND
+              </button>
+
+              <button id="editorFontReset" class="" title="Reset text editor font size to default (12px)">
+                RESET ZOOM
               </button>
 
               <button id="editorFontUp" class="" title="Increase text editor font size">

--- a/index.html
+++ b/index.html
@@ -104,6 +104,14 @@
               <button id="sendButton" class="" title="Send Text">
                 SEND
               </button>
+
+              <button id="editorFontUp" class="" title="Increase text editor font size">
+                +
+              </button>
+
+              <button id="editorFontDown" class="" title="Decrease text editor font size">
+                -
+              </button>
             </td>
           </tr>
         </table>

--- a/js/code.js
+++ b/js/code.js
@@ -394,8 +394,10 @@ Code.renderContent = function () {
   textToSend.style.display = (content.id == 'content_monitor') ? "" : "none";
   sendButton.style.display = (content.id == 'content_monitor') ? "" : "none";
 
+  var butEditorSizeReset = document.getElementById('editorFontReset');
   var butEditorSizeUp = document.getElementById('editorFontUp');
   var butEditorSizeDown = document.getElementById('editorFontDown');
+  butEditorSizeReset.style.display = (content.id == 'content_editor') ? "" : "none";
   butEditorSizeUp.style.display = (content.id == 'content_editor') ? "" : "none";
   butEditorSizeDown.style.display = (content.id == 'content_editor') ? "" : "none";
 };
@@ -601,6 +603,12 @@ Code.init = function () {
       document.getElementById('content_monitor').textContent = '';
     }
   );
+  Code.bindClick('editorFontReset',
+    function () {
+      // do not specify the actual default here, defer to Code.getAceFontSize
+      localStorage.removeItem("aceFontSize");
+      Code.ace.setFontSize(Code.getAceFontSize());
+    })
   Code.bindClick('editorFontUp',
     function () {
       Code.ace.setFontSize(Code.ace.getOption("fontSize") + 1);

--- a/js/code.js
+++ b/js/code.js
@@ -379,7 +379,10 @@ Code.renderContent = function () {
   textToSend.style.display = (content.id == 'content_monitor') ? "" : "none";
   sendButton.style.display = (content.id == 'content_monitor') ? "" : "none";
 
-
+  var butEditorSizeUp = document.getElementById('editorFontUp');
+  var butEditorSizeDown = document.getElementById('editorFontDown');
+  butEditorSizeUp.style.display = (content.id == 'content_editor') ? "" : "none";
+  butEditorSizeDown.style.display = (content.id == 'content_editor') ? "" : "none";
 };
 
 /**
@@ -583,6 +586,16 @@ Code.init = function () {
       document.getElementById('content_monitor').textContent = '';
     }
   );
+  Code.bindClick('editorFontUp',
+    function () {
+      Code.ace.setOption("fontSize", Code.ace.getOption("fontSize") + 1);
+    }
+  );
+  Code.bindClick('editorFontDown',
+  function () {
+    Code.ace.setOption("fontSize", Code.ace.getOption("fontSize") - 1);
+  }
+);
 
   // Disable the link button if page isn't backed by App Engine storage.
   var linkButton = document.getElementById('linkButton');

--- a/js/code.js
+++ b/js/code.js
@@ -76,6 +76,21 @@ Code.getBoard = function () {
 };
 
 /**
+ * Get the configured text editor font size.
+ * @returns {number} Set font size or a default.
+ */
+Code.getAceFontSize = function () {
+  let configuredSize = localStorage.getItem('aceFontSize');
+  if (configuredSize === undefined || configuredSize == null || configuredSize === "") {
+    // nothing found.
+    configuredSize = "12";
+    localStorage.setItem('aceFontSize', configuredSize);
+  }
+
+  return parseInt(configuredSize);
+}
+
+/**
  * Get the board of this user from the URL.
  * @return {string} User's board.
  */
@@ -588,12 +603,14 @@ Code.init = function () {
   );
   Code.bindClick('editorFontUp',
     function () {
-      Code.ace.setOption("fontSize", Code.ace.getOption("fontSize") + 1);
+      Code.ace.setFontSize(Code.ace.getOption("fontSize") + 1);
+      localStorage.setItem("aceFontSize", Code.ace.getOption("fontSize"));
     }
   );
   Code.bindClick('editorFontDown',
   function () {
-    Code.ace.setOption("fontSize", Code.ace.getOption("fontSize") - 1);
+    Code.ace.setFontSize(Code.ace.getOption("fontSize") - 1);
+    localStorage.setItem("aceFontSize", Code.ace.getOption("fontSize"));
   }
 );
 
@@ -1020,6 +1037,8 @@ Code.initEditor = function(init = true) {
     document.getElementById("content_arduino").readOnly = true;
     Code.ace.setReadOnly(true);
   }
+
+  Code.ace.setFontSize(Code.getAceFontSize());
 }
 
 /**


### PR DESCRIPTION
* Add `+` and `-` buttons to change text editor font size by ±1 pixel (0d8adb4aa279bf4fa768fa5a4344c0177f2d85b9)
* Add reset button to reset size back to 12px, the default (8e97c1845509d23652b896d47fe2e090ae93e066)
* Remember this set font size in local storage (9da42c291ae4b60ea6e0fa66425825935e4608fb)