### PR TITLE
Wire up <select> tags (dropdowns) using change HTML event instead of click event

### DIFF
--- a/js/code.js
+++ b/js/code.js
@@ -563,24 +563,22 @@ Code.init = function () {
 
   auto_backup_and_restore_blocks();
 
-  Code.bindClick('boardSelect',
-    function () {
-      localStorage.setItem('board', this.value);
-      document.getElementById('board').textContent = document.getElementById('boardSelect').value;//MSG['title'];
+  document.getElementById("boardSelect").addEventListener("change", function () {
+    localStorage.setItem('board', this.value);
+    document.getElementById('board').textContent = document.getElementById('boardSelect').value;//MSG['title'];
 
-      if (this.value == "ezDisplay" || Code.getLesson() == "ezDisplay") {
-        document.getElementById("img2hex").classList.remove("hide")
-        document.getElementById("compileButton").classList.add("hide")
-      } else {
-        document.getElementById("img2hex").classList.add("hide")
-        document.getElementById("compileButton").classList.remove("hide")
-      }
+    if (this.value == "ezDisplay" || Code.getLesson() == "ezDisplay") {
+      document.getElementById("img2hex").classList.remove("hide")
+      document.getElementById("compileButton").classList.add("hide")
+    } else {
+      document.getElementById("img2hex").classList.add("hide")
+      document.getElementById("compileButton").classList.remove("hide")
+    }
 
-      onresize();
-    });
+    onresize();
+  })
 
-  Code.bindClick('lessonSelect',
-    function () {
+  document.getElementById("lessonSelect").addEventListener("change", function () {
       let prev = Code.getLesson();
       localStorage.setItem('lesson', this.value);
       if (prev != this.value) {
@@ -605,7 +603,6 @@ Code.init = function () {
         }
 
         onresize();
-      }
     });
 
   Code.tabClick(Code.selected);

--- a/js/code.js
+++ b/js/code.js
@@ -579,31 +579,32 @@ Code.init = function () {
   })
 
   document.getElementById("lessonSelect").addEventListener("change", function () {
-      let prev = Code.getLesson();
-      localStorage.setItem('lesson', this.value);
-      if (prev != this.value) {
-        // document.getElementById('title').textContent = document.getElementById('lessonSelect').value;//MSG['title'];
-        let newTree = Code.buildToolbox(this.value);
-        Code.workspace.updateToolbox(newTree);
-        console.log(this.value)
-        if (prev != 'bot' && this.value === 'bot') {
-          document.getElementById('title').textContent = "BOT";
-          Code.discard();
-        } else {
-          document.getElementById('title').textContent = "Advanced";
-          Code.switchLoops();
-        }
+    let prev = Code.getLesson();
+    localStorage.setItem('lesson', this.value);
+    if (prev != this.value) {
+      // document.getElementById('title').textContent = document.getElementById('lessonSelect').value;//MSG['title'];
+      let newTree = Code.buildToolbox(this.value);
+      Code.workspace.updateToolbox(newTree);
+      console.log(this.value)
+      if (prev != 'bot' && this.value === 'bot') {
+        document.getElementById('title').textContent = "BOT";
+        Code.discard();
+      } else {
+        document.getElementById('title').textContent = "Advanced";
+        Code.switchLoops();
+      }
 
-        if (this.value == "ezDisplay" || Code.getBoard() == "ezDisplay") {
-          document.getElementById("img2hex").classList.remove("hide")
-          document.getElementById("compileButton").classList.add("hide")
-        } else {
-          document.getElementById("img2hex").classList.add("hide")
-          document.getElementById("compileButton").classList.remove("hide")
-        }
+      if (this.value == "ezDisplay" || Code.getBoard() == "ezDisplay") {
+        document.getElementById("img2hex").classList.remove("hide")
+        document.getElementById("compileButton").classList.add("hide")
+      } else {
+        document.getElementById("img2hex").classList.add("hide")
+        document.getElementById("compileButton").classList.remove("hide")
+      }
 
-        onresize();
-    });
+      onresize();
+    }
+  });
 
   Code.tabClick(Code.selected);
 


### PR DESCRIPTION
Resolves an issue found on some older macOS systems. Should also more reliably support keyboard navigation.