### PR TITLE
Add analog pin and analog read blocks

### DIFF
--- a/blocks/custom_blocks.js
+++ b/blocks/custom_blocks.js
@@ -691,8 +691,8 @@ Blockly.Blocks["extra_logic"] = {
     this.setTooltip(function () {
       var op = thisBlock.getFieldValue("OP");
       var TOOLTIPS = {
-        "XOR": "bazinga",
-        "NOR": "bazinga"
+        "XOR": "eXclusive OR - true only if inputs differ",
+        "NOR": "neither NOR - true only if both inputs are false"
       };
       return TOOLTIPS[op];
     });

--- a/blocks/custom_blocks.js
+++ b/blocks/custom_blocks.js
@@ -719,6 +719,35 @@ Blockly.Blocks["pulsein"] = {
   }
 };
 
+Blockly.Blocks["analog_pin"] = {
+  init: function () {
+    this.setOutput(true, "AnalogPin")
+    this.setColour(230)
+
+    this.appendDummyInput().appendField(new Blockly.FieldDropdown([
+        ["A0", "A0"],
+        ["A1", "A1"],
+        ["A2", "A2"],
+        ["A3", "A3"],
+        ["A4", "A4"],
+        ["A5", "A5"],
+      ]), "PIN");
+  }
+}
+
+Blockly.Blocks["analog_read"] = {
+  init: function () {
+    this.setHelpUrl("https://www.arduino.cc/reference/en/language/functions/analog-io/analogread/");
+    this.setColour(180);
+    this.appendValueInput("PIN")
+      .setCheck(["AnalogPin"])
+      .appendField("ANALOG READ pin ");
+    this.setInputsInline(true);
+    this.setOutput(true, "Number");
+    this.setTooltip("Get analog voltage of a pin, 0-1023.");
+  }
+};
+
 Blockly.Blocks["SSD1306_clear"] = {
   init: function () {
     this.setTooltip("Clear the currently rendered framebuffer.");

--- a/generators/custom_generators.js
+++ b/generators/custom_generators.js
@@ -30,6 +30,19 @@ Blockly.Arduino.pulsein = function () {
     return [code, Blockly.Arduino.ORDER_ATOMIC];
 };
 
+Blockly.Arduino.analog_pin = function (block) {
+    const pin = Blockly.Arduino.valueToCode(block, "PIN", Blockly.Arduino.ORDER_ATOMIC) || "A0";
+
+    return [`${pin}`, Blockly.Arduino.ORDER_FUNCTION_CALL]
+}
+
+Blockly.Arduino.analog_read = function (block) {
+    const pin = block.getFieldValue("PIN", Blockly.Arduino.ORDER_ATOMIC) || "A0";
+
+    Blockly.Arduino.setups_["setup_input_" + pin] = `pinMode(${pin}, INPUT);`;
+    return [`analogRead(${pin})`, Blockly.Arduino.ORDER_FUNCTION_CALL]
+}
+
 Blockly.Arduino.sensors_sonic = function (block) {
     const echoPin = Blockly.Arduino.valueToCode(block, "ECHO", Blockly.Arduino.ORDER_ATOMIC) || "3";
     const triggerPin = Blockly.Arduino.valueToCode(block, "TRIGGER", Blockly.Arduino.ORDER_ATOMIC) || "4";

--- a/generators/custom_generators.js
+++ b/generators/custom_generators.js
@@ -39,7 +39,7 @@ Blockly.Arduino.analog_pin = function (block) {
 Blockly.Arduino.analog_read = function (block) {
     const pin = block.getFieldValue("PIN", Blockly.Arduino.ORDER_ATOMIC) || "A0";
 
-    Blockly.Arduino.setups_["setup_input_" + pin] = `pinMode(${pin}, INPUT);`;
+    Blockly.Arduino.setups_["setup_output_" + pin] = `pinMode(${pin}, INPUT);`;
     return [`analogRead(${pin})`, Blockly.Arduino.ORDER_FUNCTION_CALL]
 }
 

--- a/generators/custom_generators.js
+++ b/generators/custom_generators.js
@@ -31,13 +31,13 @@ Blockly.Arduino.pulsein = function () {
 };
 
 Blockly.Arduino.analog_pin = function (block) {
-    const pin = Blockly.Arduino.valueToCode(block, "PIN", Blockly.Arduino.ORDER_ATOMIC) || "A0";
+    const pin = block.getFieldValue("PIN", Blockly.Arduino.ORDER_ATOMIC) || "A0";
 
-    return [`${pin}`, Blockly.Arduino.ORDER_FUNCTION_CALL]
+    return [`${pin}`, Blockly.Arduino.ORDER_ATOMIC]
 }
 
 Blockly.Arduino.analog_read = function (block) {
-    const pin = block.getFieldValue("PIN", Blockly.Arduino.ORDER_ATOMIC) || "A0";
+    const pin = Blockly.Arduino.valueToCode(block, "PIN", Blockly.Arduino.ORDER_ATOMIC) || "A0";
 
     Blockly.Arduino.setups_["setup_output_" + pin] = `pinMode(${pin}, INPUT);`;
     return [`analogRead(${pin})`, Blockly.Arduino.ORDER_FUNCTION_CALL]

--- a/index.html
+++ b/index.html
@@ -242,6 +242,7 @@
         <field name="NUM">123</field>
       </block>
       <block type="math_constant"></block>
+      <block type="analog_pin"></block>
       <block type="boolean_onoff"></block>
       <block type="boolean_hilo"></block>
       <block type="text"></block>
@@ -320,6 +321,13 @@
         </value>
         <value name="B">
           <block type="boolean_pressed"></block>
+        </value>
+      </block>
+      <block type="analog_read">
+        <value name="PIN">
+          <block type="analog_pin">
+            <field name="PIN">A0</field>
+          </block>
         </value>
       </block>
       <block type="sensors_sonic">


### PR DESCRIPTION
* Adds new block type, `AnalogPin`.
* Adds new analog pin literal block with options A0-A5. More pins are available on other boards, but this project targets Uno and Nano so we will stay within the range for those boards.
* Adds new analog read block, returning the unaltered 10 bits from hardware. This is mutually exclusive with using a pin as a button input or any kind of output.
* Unrelated change: adds a tooltip for the XOR/NOR block depending on which of these two options is selected.
* Brews more coffee.